### PR TITLE
feat: port ls function

### DIFF
--- a/src/App/app.css
+++ b/src/App/app.css
@@ -27,7 +27,7 @@ h1 {
 }
 #path-container {
   flex-grow: 1;
-  margin: 0 20px;
+  display: flex;
 }
 #path-input {
   width: 100%;

--- a/src/App/app.css
+++ b/src/App/app.css
@@ -28,6 +28,7 @@ h1 {
 #path-container {
   flex-grow: 1;
   display: flex;
+  margin-left: 20px;
 }
 #path-input {
   width: 100%;

--- a/src/App/app.tsx
+++ b/src/App/app.tsx
@@ -9,6 +9,7 @@ export const App = () => {
   const [message, setMessage] = useState("");
   const [chatHistory, setChatHistory] = useState<IMessage[]>([]);
   const [isTyping, setIsTyping] = useState(false);
+  const [rootDir, setRootDDir] = useState(window.electron.get("rootDir"));
   const chatContainerRef = useRef<HTMLDivElement>(null);
 
   const handleSendMessage = async () => {
@@ -47,7 +48,15 @@ export const App = () => {
             type="text"
             id="path-input"
             placeholder="Enter root directory..."
+            value={rootDir}
+            onChange={(e) => setRootDDir(e.target.value)}
           />
+          <button
+            id="header-button"
+            onClick={() => window.electron.set("rootDir", rootDir)}
+          >
+            Save
+          </button>
         </div>
         <div style={{ paddingLeft: "10px" }}>
           <button id="header-button" title="Restart Session">

--- a/src/helpers/chatCompletion.ts
+++ b/src/helpers/chatCompletion.ts
@@ -17,6 +17,7 @@ export const chatCompletion = ({
     {
       apiKey: settings.apiKey,
       modelName: settings.modelName,
+      rootDir: settings.rootDir,
       messages: newChatHistory.map((m: IMessage) => ({
         role: m.role,
         content: m.content,

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ ipcMain.on("all-settings-set", (_, val) => {
 
 ipcMain.on(
   "chat:completion",
-  async (event, { apiKey, modelName, messages }) => {
+  async (event, { apiKey, modelName, rootDir, messages }) => {
     event.reply("chat:completion-update", { type: "start", success: true });
     try {
       const openai = new OpenAI({
@@ -109,7 +109,7 @@ ipcMain.on(
                 isNotification: true,
               });
               const args = JSON.parse(toolCall.function.arguments);
-              const result = await functionToCall({ ...args, apiKey });
+              const result = await functionToCall({ ...args, apiKey, rootDir });
               event.reply("chat:completion-update", {
                 type: "update",
                 success: true,

--- a/src/main.d.ts
+++ b/src/main.d.ts
@@ -8,7 +8,7 @@ export interface ISettings {
 }
 
 export interface IChatCompletionMessage {
-  role: 'user' | 'assistant';
+  role: "user" | "assistant";
   content: string;
 }
 
@@ -16,10 +16,11 @@ export interface IChatCompletionOptions {
   apiKey: string;
   modelName: string;
   messages: IChatCompletionMessage[];
+  rootDir: string;
 }
 
 export interface IChatCompletionUpdate {
-  type: 'start' | 'update' | 'end';
+  type: "start" | "update" | "end";
   success: boolean;
   message?: string;
   isNotification?: boolean;

--- a/src/tools/checkDirectory.ts
+++ b/src/tools/checkDirectory.ts
@@ -1,0 +1,54 @@
+import fs from "fs";
+import path from "path";
+import { ChatCompletionTool } from "openai/resources/chat/completions";
+
+export async function checkDirectory({
+  rootDir,
+  directoryPath = "",
+}: {
+  directoryPath?: string;
+  rootDir: string;
+}) {
+  if (!rootDir) {
+    throw new Error("Root directory is not specified.");
+  }
+
+  const dir = path.resolve(rootDir, directoryPath);
+
+  // Security check to ensure the path is within the root directory
+  const relative = path.relative(rootDir, dir);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(
+      "Access to paths outside the root directory is not allowed."
+    );
+  }
+
+  const items = fs
+    .readdirSync(dir)
+    .map((item) => {
+      const itemPath = path.join(dir, item);
+      return fs.statSync(itemPath).isDirectory() ? `${item}/` : item;
+    })
+    .sort();
+
+  return items.join("\n");
+}
+
+export const checkDirectoryTool: ChatCompletionTool = {
+  type: "function",
+  function: {
+    name: "checkDirectory",
+    description:
+      "List files and directories in the specified path relative to root directory.",
+    parameters: {
+      type: "object",
+      properties: {
+        directoryPath: {
+          type: "string",
+          description:
+            "The path to list files and directories in. Defaults to the root directory.",
+        },
+      },
+    },
+  },
+};

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,9 +1,11 @@
 import { rollDice, rollDiceTool } from "./rollDice";
 import { checkOnline, checkOnlineTool } from "./checkOnline";
+import { checkDirectory, checkDirectoryTool } from "./checkDirectory";
 
-export const tools = [rollDiceTool, checkOnlineTool];
+export const tools = [rollDiceTool, checkOnlineTool, checkDirectoryTool];
 
 export const toolExecutor: { [key: string]: (args: any) => any } = {
   rollDice,
   checkOnline,
+  checkDirectory,
 };


### PR DESCRIPTION
- Renamed to `checkDirectory`
- Changed `chatCompletion` callback so it also passes rootDir
- rootDir is updated in store whenever changed 
    - Add a save button for rootDir so that we don't have to constantly inform tools about change in rootDir